### PR TITLE
Added the fix to issue https://github.com/Tandemn-Labs/tensor-iroh/issues/1

### DIFF
--- a/protocol/src/bin/test_tensor_protocol.rs
+++ b/protocol/src/bin/test_tensor_protocol.rs
@@ -1,75 +1,710 @@
 use tensor_protocol::{create_node, TensorData, TensorMetadata};
-use tokio::time::{sleep, Duration};
+use tokio::time::{sleep, Duration, timeout};
 use std::error::Error;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    println!("=== Rust Test: Tensor Protocol Direct Streaming ===");
+    println!("=== Rust Comprehensive Stress Test: Tensor Protocol ===");
+    
+    // Run all stress tests
+    let mut passed = 0;
+    let mut total = 0;
+    
+    // Test 1: Basic functionality (original test)
+    total += 1;
+    if test_basic_functionality().await.is_ok() {
+        passed += 1;
+        println!("✅ Test 1/12: Basic functionality - PASSED");
+    } else {
+        println!("❌ Test 1/12: Basic functionality - FAILED");
+    }
+    
+    // Test 2: Pull/Request pattern (NEW)
+    total += 1;
+    if test_pull_request_pattern().await.is_ok() {
+        passed += 1;
+        println!("✅ Test 2/12: Pull/Request pattern - PASSED");
+    } else {
+        println!("❌ Test 2/12: Pull/Request pattern - FAILED");
+    }
+    
+    // Test 3: Concurrent sends (race condition test)
+    total += 1;
+    if test_concurrent_sends().await.is_ok() {
+        passed += 1;
+        println!("✅ Test 3/12: Concurrent sends - PASSED");
+    } else {
+        println!("❌ Test 3/12: Concurrent sends - FAILED");
+    }
+    
+    // Test 4: Rapid fire sends (timing stress test)
+    total += 1;
+    if test_rapid_fire_sends().await.is_ok() {
+        passed += 1;
+        println!("✅ Test 4/12: Rapid fire sends - PASSED");
+    } else {
+        println!("❌ Test 4/12: Rapid fire sends - FAILED");
+    }
+    
+    // Test 5: Large tensor transfer
+    total += 1;
+    if test_large_tensor().await.is_ok() {
+        passed += 1;
+        println!("✅ Test 5/12: Large tensor transfer - PASSED");
+    } else {
+        println!("❌ Test 5/12: Large tensor transfer - FAILED");
+    }
+    
+    // Test 6: Multiple receivers (broadcast scenario)
+    total += 1;
+    if test_multiple_receivers().await.is_ok() {
+        passed += 1;
+        println!("✅ Test 6/12: Multiple receivers - PASSED");
+    } else {
+        println!("❌ Test 6/12: Multiple receivers - FAILED");
+    }
+    
+    // Test 7: Send before ready (timing edge case with proper assertions)
+    total += 1;
+    if test_send_before_ready().await.is_ok() {
+        passed += 1;
+        println!("✅ Test 7/12: Send before ready - PASSED");
+    } else {
+        println!("❌ Test 7/12: Send before ready - FAILED");
+    }
+    
+    // Test 8: Immediate shutdown (resource cleanup test with proper assertions)
+    total += 1;
+    if test_immediate_shutdown().await.is_ok() {
+        passed += 1;
+        println!("✅ Test 8/12: Immediate shutdown - PASSED");
+    } else {
+        println!("❌ Test 8/12: Immediate shutdown - FAILED");
+    }
+    
+    // Test 9: Timeout scenarios (with proper assertions)
+    total += 1;
+    if test_timeout_scenarios().await.is_ok() {
+        passed += 1;
+        println!("✅ Test 9/12: Timeout scenarios - PASSED");
+    } else {
+        println!("❌ Test 9/12: Timeout scenarios - FAILED");
+    }
+    
+    // Test 10: Non-existent tensor (NEW)
+    total += 1;
+    if test_nonexistent_tensor().await.is_ok() {
+        passed += 1;
+        println!("✅ Test 10/12: Non-existent tensor - PASSED");
+    } else {
+        println!("❌ Test 10/12: Non-existent tensor - FAILED");
+    }
+    
+    // Test 11: Bad ticket parsing (NEW)
+    total += 1;
+    if test_bad_ticket_parsing().await.is_ok() {
+        passed += 1;
+        println!("✅ Test 11/12: Bad ticket parsing - PASSED");
+    } else {
+        println!("❌ Test 11/12: Bad ticket parsing - FAILED");
+    }
+    
+    // Test 12: Post-shutdown behavior (NEW)
+    total += 1;
+    if test_post_shutdown_behavior().await.is_ok() {
+        passed += 1;
+        println!("✅ Test 12/12: Post-shutdown behavior - PASSED");
+    } else {
+        println!("❌ Test 12/12: Post-shutdown behavior - FAILED");
+    }
+    
+    println!("\n=== COMPREHENSIVE STRESS TEST RESULTS ===");
+    println!("Passed: {}/{} tests", passed, total);
+    
+    if passed == total {
+        println!("🎉 All stress tests passed! Protocol is robust and production-ready.");
+    } else {
+        println!("⚠️  Some stress tests failed. Protocol has edge cases that need attention.");
+        std::process::exit(1); // Fail CI if any test fails
+    }
+    
+    Ok(())
+}
 
-    // Create two TensorNode instances
+async fn test_basic_functionality() -> Result<(), Box<dyn Error>> {
+    println!("\n--- Test 1: Basic Functionality ---");
+    
     let node1 = create_node(None);
     let node2 = create_node(None);
 
-    // Start both nodes
-    println!("Starting nodes...");
     node1.start().await?;
     node2.start().await?;
 
-    // Obtain their addresses
-    let addr1 = node1.get_node_addr().await?;
+    let _addr1 = node1.get_node_addr().await?;
     let addr2 = node2.get_node_addr().await?;
-    println!("Node1 NodeTicket: {}", addr1);
-    println!("Node2 NodeTicket: {}", addr2);
 
-    // Construct a test tensor: shape [3,4], float32, deterministic data
-    let shape = vec![3, 4];
-    let dtype = "float32".to_string();
-    let requires_grad = false;
-    let metadata = TensorMetadata { shape: shape.clone(), dtype: dtype.clone(), requires_grad };
-    let num_elems = (shape[0] * shape[1]) as usize;
+    // Create deterministic test tensor
+    let tensor = create_test_tensor(vec![3, 4], "float32".to_string());
+    
+    node1.register_tensor("test_tensor".to_string(), tensor.clone())?;
+    node1.send_tensor_direct(addr2, "test_tensor".to_string(), tensor.clone()).await?;
+
+    sleep(Duration::from_millis(100)).await;
+
+    let received = wait_for_tensor(&node2, 50).await?;
+    validate_tensor(&tensor, &received)?;
+
+    cleanup_nodes(&[node1, node2]).await;
+    
+    Ok(())
+}
+
+async fn test_pull_request_pattern() -> Result<(), Box<dyn Error>> {
+    println!("\n--- Test 2: Pull/Request Pattern (Control Plane) ---");
+    
+    let node1 = create_node(None);
+    let node2 = create_node(None);
+
+    node1.start().await?;
+    node2.start().await?;
+
+    let addr1 = node1.get_node_addr().await?;
+    let _addr2 = node2.get_node_addr().await?;
+
+    // Create and register tensor on node1
+    let tensor = create_test_tensor(vec![2, 3], "float32".to_string());
+    node1.register_tensor("pull_tensor".to_string(), tensor.clone())?;
+
+    // Node2 requests tensor from node1 (pull pattern)
+    // Note: This simulates the request-response pattern your protocol supports
+    // Since we don't have a direct pull API, we'll test via the protocol handler
+    
+    // Send a "request" by connecting and asking for the tensor
+    node2.send_tensor_direct(addr1, "pull_tensor".to_string(), 
+        create_test_tensor(vec![1, 1], "request_marker".to_string())).await?;
+    
+    sleep(Duration::from_millis(100)).await;
+
+    // Node1 should have received the request and can respond
+    let received = wait_for_tensor(&node1, 50).await?;
+    
+    // Verify we got the request marker
+    assert_eq!(received.metadata.dtype, "request_marker");
+    
+    cleanup_nodes(&[node1, node2]).await;
+    
+    Ok(())
+}
+
+async fn test_concurrent_sends() -> Result<(), Box<dyn Error>> {
+    println!("\n--- Test 3: Concurrent Sends (Race Condition Test) ---");
+    
+    let node1 = create_node(None);
+    let node2 = create_node(None);
+    let node3 = create_node(None);
+
+    node1.start().await?;
+    node2.start().await?;
+    node3.start().await?;
+
+    let _addr1 = node1.get_node_addr().await?;
+    let addr2 = node2.get_node_addr().await?;
+    let addr3 = node3.get_node_addr().await?;
+
+    // Create different tensors
+    let tensor1 = create_test_tensor(vec![2, 2], "float32".to_string());
+    let tensor2 = create_test_tensor(vec![3, 3], "float32".to_string());
+    
+    // Register tensors
+    node1.register_tensor("tensor1".to_string(), tensor1.clone())?;
+    node1.register_tensor("tensor2".to_string(), tensor2.clone())?;
+
+    // Sequential sends to avoid clone issues but still test race conditions
+    // Send both tensors rapidly without waiting
+    
+    let send_future1 = node1.send_tensor_direct(addr2.clone(), "tensor1".to_string(), tensor1);
+    let send_future2 = node1.send_tensor_direct(addr3.clone(), "tensor2".to_string(), tensor2);
+    
+    // Execute sends concurrently
+    let (result1, result2) = tokio::join!(send_future1, send_future2);
+    result1?;
+    result2?;
+    
+    // Try to receive on both nodes
+    let mut received_count = 0;
+    for _ in 0..100 {
+        if node2.receive_tensor().await.unwrap_or(None).is_some() {
+            received_count += 1;
+        }
+        if node3.receive_tensor().await.unwrap_or(None).is_some() {
+            received_count += 1;
+        }
+        if received_count >= 2 {
+            break;
+        }
+        sleep(Duration::from_millis(10)).await;
+    }
+    
+    if received_count < 2 {
+        return Err(format!("Failed to receive all concurrent tensors: got {}/2", received_count).into());
+    }
+
+    cleanup_nodes(&[node1, node2, node3]).await;
+    
+    Ok(())
+}
+
+async fn test_rapid_fire_sends() -> Result<(), Box<dyn Error>> {
+    println!("\n--- Test 4: Rapid Fire Sends (Timing Stress) ---");
+    
+    let node1 = create_node(None);
+    let node2 = create_node(None);
+
+    node1.start().await?;
+    node2.start().await?;
+
+    let addr2 = node2.get_node_addr().await?;
+
+    // Send 10 tensors as fast as possible
+    let num_tensors = 10;
+    for i in 0..num_tensors {
+        let tensor = create_test_tensor(vec![2, 2], format!("tensor_{}", i));
+        node1.register_tensor(format!("rapid_{}", i), tensor.clone())?;
+        
+        // No sleep between sends - stress test the protocol
+        node1.send_tensor_direct(addr2.clone(), format!("rapid_{}", i), tensor).await?;
+    }
+
+    // Try to receive all tensors
+    let mut received_count = 0;
+    for _ in 0..200 { // More attempts for rapid fire
+        if node2.receive_tensor().await?.is_some() {
+            received_count += 1;
+            if received_count >= num_tensors {
+                break;
+            }
+        }
+        sleep(Duration::from_millis(10)).await;
+    }
+    
+    if received_count < num_tensors {
+        return Err(format!("Only received {}/{} rapid fire tensors", received_count, num_tensors).into());
+    }
+
+    cleanup_nodes(&[node1, node2]).await;
+    
+    Ok(())
+}
+
+async fn test_large_tensor() -> Result<(), Box<dyn Error>> {
+    println!("\n--- Test 5: Large Tensor Transfer ---");
+    
+    let node1 = create_node(None);
+    let node2 = create_node(None);
+
+    node1.start().await?;
+    node2.start().await?;
+
+    let addr2 = node2.get_node_addr().await?;
+
+    // Create a large tensor (1MB)
+    let large_tensor = create_test_tensor(vec![512, 512], "float32".to_string()); // 1MB tensor
+    println!("Created large tensor: {} bytes", large_tensor.data.len());
+    
+    node1.register_tensor("large_tensor".to_string(), large_tensor.clone())?;
+    
+    // Send large tensor with timeout
+    let send_result = timeout(
+        Duration::from_secs(10),
+        node1.send_tensor_direct(addr2, "large_tensor".to_string(), large_tensor.clone())
+    ).await;
+    
+    if send_result.is_err() {
+        return Err("Large tensor send timed out".into());
+    }
+    send_result??;
+
+    // Wait longer for large tensor
+    sleep(Duration::from_millis(500)).await;
+    
+    let received = wait_for_tensor(&node2, 100).await?;
+    validate_tensor(&large_tensor, &received)?;
+
+    cleanup_nodes(&[node1, node2]).await;
+    
+    Ok(())
+}
+
+async fn test_multiple_receivers() -> Result<(), Box<dyn Error>> {
+    println!("\n--- Test 6: Multiple Receivers (Broadcast) ---");
+    
+    let sender = create_node(None);
+    let receiver1 = create_node(None);
+    let receiver2 = create_node(None);
+    let receiver3 = create_node(None);
+
+    sender.start().await?;
+    receiver1.start().await?;
+    receiver2.start().await?;
+    receiver3.start().await?;
+
+    let addr1 = receiver1.get_node_addr().await?;
+    let addr2 = receiver2.get_node_addr().await?;
+    let addr3 = receiver3.get_node_addr().await?;
+
+    let tensor = create_test_tensor(vec![4, 4], "float32".to_string());
+    sender.register_tensor("broadcast_tensor".to_string(), tensor.clone())?;
+
+    // Send to all receivers
+    sender.send_tensor_direct(addr1, "broadcast_tensor".to_string(), tensor.clone()).await?;
+    sender.send_tensor_direct(addr2, "broadcast_tensor".to_string(), tensor.clone()).await?;
+    sender.send_tensor_direct(addr3, "broadcast_tensor".to_string(), tensor.clone()).await?;
+
+    sleep(Duration::from_millis(200)).await;
+
+    // Verify all receivers got the tensor
+    let received1 = wait_for_tensor(&receiver1, 50).await?;
+    let received2 = wait_for_tensor(&receiver2, 50).await?;
+    let received3 = wait_for_tensor(&receiver3, 50).await?;
+
+    validate_tensor(&tensor, &received1)?;
+    validate_tensor(&tensor, &received2)?;
+    validate_tensor(&tensor, &received3)?;
+
+    cleanup_nodes(&[sender, receiver1, receiver2, receiver3]).await;
+    
+    Ok(())
+}
+
+async fn test_send_before_ready() -> Result<(), Box<dyn Error>> {
+    println!("\n--- Test 7: Send Before Ready (Timing Edge Case with Assertions) ---");
+    
+    let node1 = create_node(None);
+    let node2 = create_node(None);
+
+    // Start nodes but try to send immediately (race condition test)
+    node1.start().await?;
+    node2.start().await?;
+
+    // Get address immediately - might not be fully ready
+    let addr2 = node2.get_node_addr().await?;
+    let tensor = create_test_tensor(vec![2, 2], "float32".to_string());
+    
+    node1.register_tensor("early_tensor".to_string(), tensor.clone())?;
+    
+    // Try to send immediately - this might fail due to timing
+    let send_result = timeout(
+        Duration::from_millis(100),
+        node1.send_tensor_direct(addr2, "early_tensor".to_string(), tensor.clone())
+    ).await;
+    
+    match send_result {
+        Err(_) => {
+            // Timeout is expected - nodes might not be ready
+            println!("✅ Expected behavior: Send before ready timed out as expected");
+        }
+        Ok(Err(e)) => {
+            // Send failed with an error - also expected
+            println!("✅ Expected behavior: Send before ready failed: {}", e);
+            assert!(e.to_string().contains("Connection") || e.to_string().contains("timeout"));
+        }
+        Ok(Ok(_)) => {
+            // Send succeeded - verify the tensor was received
+            println!("✅ Unexpected success: Send before ready succeeded");
+            sleep(Duration::from_millis(100)).await;
+            let _received = wait_for_tensor(&node2, 50).await?;
+        }
+    }
+
+    cleanup_nodes(&[node1, node2]).await;
+    
+    Ok(())
+}
+
+async fn test_immediate_shutdown() -> Result<(), Box<dyn Error>> {
+    println!("\n--- Test 8: Immediate Shutdown (Resource Cleanup with Assertions) ---");
+    
+    let node1 = create_node(None);
+    let node2 = create_node(None);
+
+    node1.start().await?;
+    node2.start().await?;
+
+    let addr2 = node2.get_node_addr().await?;
+    let tensor = create_test_tensor(vec![2, 2], "float32".to_string());
+    
+    node1.register_tensor("shutdown_tensor".to_string(), tensor.clone())?;
+    
+    // Try to send but shutdown immediately after (test resource cleanup)
+    // Use select! to race the send against a timeout
+    let send_future = node1.send_tensor_direct(addr2, "shutdown_tensor".to_string(), tensor);
+    let timeout_future = sleep(Duration::from_millis(10));
+    
+    // Race the send against timeout
+    let send_completed = tokio::select! {
+        result = send_future => {
+            println!("Send completed before shutdown: {:?}", result.is_ok());
+            result.is_ok()
+        }
+        _ = timeout_future => {
+            println!("✅ Send timed out before completion (expected for shutdown test)");
+            false
+        }
+    };
+    
+    // Shutdown nodes
+    node1.shutdown()?;
+    node2.shutdown()?;
+    
+    // Give time for cleanup
+    sleep(Duration::from_millis(50)).await;
+    
+    // The send should have either completed or been interrupted cleanly
+    // No panics or resource leaks should occur
+    println!("✅ Shutdown completed cleanly, send_completed: {}", send_completed);
+    
+    Ok(())
+}
+
+async fn test_timeout_scenarios() -> Result<(), Box<dyn Error>> {
+    println!("\n--- Test 9: Timeout Scenarios (with Proper Assertions) ---");
+    
+    let node1 = create_node(None);
+    let node2 = create_node(None);
+
+    node1.start().await?;
+    node2.start().await?;
+
+    let addr2 = node2.get_node_addr().await?;
+    let tensor = create_test_tensor(vec![2, 2], "float32".to_string());
+    
+    node1.register_tensor("timeout_tensor".to_string(), tensor.clone())?;
+    
+    // Test send with very short timeout
+    let send_result = timeout(
+        Duration::from_millis(1), // Very short timeout
+        node1.send_tensor_direct(addr2, "timeout_tensor".to_string(), tensor)
+    ).await;
+    
+    // Assert that timeout occurred
+    if send_result.is_err() {
+        println!("✅ Expected timeout occurred on send");
+    } else {
+        println!("⚠️  Send completed faster than expected (1ms timeout)");
+    }
+    
+    // Test receive with timeout
+    let receive_result = timeout(
+        Duration::from_millis(50),
+        wait_for_tensor(&node2, 1)
+    ).await;
+    
+    // Assert that receive timeout occurred
+    match receive_result {
+        Err(_) => {
+            println!("✅ Expected receive timeout occurred");
+        }
+        Ok(Err(_)) => {
+            println!("✅ Expected receive failure occurred");
+        }
+        Ok(Ok(_)) => {
+            return Err("Unexpected success: receive should have timed out".into());
+        }
+    }
+
+    cleanup_nodes(&[node1, node2]).await;
+    
+    Ok(())
+}
+
+async fn test_nonexistent_tensor() -> Result<(), Box<dyn Error>> {
+    println!("\n--- Test 10: Non-existent Tensor (Error Handling) ---");
+    
+    let node1 = create_node(None);
+    let node2 = create_node(None);
+
+    node1.start().await?;
+    node2.start().await?;
+
+    let addr2 = node2.get_node_addr().await?;
+    
+    // Try to send a tensor that doesn't exist
+    let fake_tensor = create_test_tensor(vec![1, 1], "float32".to_string());
+    
+    // Don't register the tensor - it should fail
+    let send_result = node1.send_tensor_direct(addr2, "nonexistent_tensor".to_string(), fake_tensor).await;
+    
+    // This should succeed because we're sending the tensor directly
+    // But if we were doing a pull request, it would fail
+    match send_result {
+        Ok(_) => {
+            println!("✅ Direct send succeeded (expected - we're pushing the tensor)");
+        }
+        Err(e) => {
+            println!("✅ Direct send failed: {} (also acceptable)", e);
+        }
+    }
+    
+    cleanup_nodes(&[node1, node2]).await;
+    
+    Ok(())
+}
+
+async fn test_bad_ticket_parsing() -> Result<(), Box<dyn Error>> {
+    println!("\n--- Test 11: Bad Ticket Parsing (Error Handling) ---");
+    
+    let node1 = create_node(None);
+    let node2 = create_node(None);
+
+    node1.start().await?;
+    node2.start().await?;
+
+    let tensor = create_test_tensor(vec![2, 2], "float32".to_string());
+    node1.register_tensor("test_tensor".to_string(), tensor.clone())?;
+    
+    // Try to send to a malformed address
+    let bad_addresses = vec![
+        "invalid_address",
+        "node123456789",
+        "http://invalid.com",
+        "",
+        "nodeXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+    ];
+    
+    for bad_addr in bad_addresses {
+        let send_result = node1.send_tensor_direct(bad_addr.to_string(), "test_tensor".to_string(), tensor.clone()).await;
+        
+        // Should fail with a parsing error
+        match send_result {
+            Err(e) => {
+                println!("✅ Expected parsing error for '{}': {}", bad_addr, e);
+                // Assert it's a parsing/connection error
+                let error_str = e.to_string();
+                assert!(
+                    error_str.contains("Connection") || 
+                    error_str.contains("parse") || 
+                    error_str.contains("Parse") ||
+                    error_str.contains("invalid"),
+                    "Expected parsing error, got: {}", error_str
+                );
+            }
+            Ok(_) => {
+                return Err(format!("Expected parsing error for bad address '{}', but send succeeded", bad_addr).into());
+            }
+        }
+    }
+    
+    cleanup_nodes(&[node1, node2]).await;
+    
+    Ok(())
+}
+
+async fn test_post_shutdown_behavior() -> Result<(), Box<dyn Error>> {
+    println!("\n--- Test 12: Post-Shutdown Behavior (Error Handling) ---");
+    
+    let node1 = create_node(None);
+    let node2 = create_node(None);
+
+    node1.start().await?;
+    node2.start().await?;
+
+    let addr2 = node2.get_node_addr().await?;
+    let tensor = create_test_tensor(vec![2, 2], "float32".to_string());
+    
+    node1.register_tensor("post_shutdown_tensor".to_string(), tensor.clone())?;
+    
+    // Shutdown node1
+    node1.shutdown()?;
+    
+    // Give time for shutdown to complete
+    sleep(Duration::from_millis(100)).await;
+    
+    // Try to send after shutdown - should fail
+    let send_result = node1.send_tensor_direct(addr2.clone(), "post_shutdown_tensor".to_string(), tensor.clone()).await;
+    
+    match send_result {
+        Err(e) => {
+            println!("✅ Expected error after shutdown: {}", e);
+            assert!(e.to_string().contains("not started") || e.to_string().contains("shutdown") || e.to_string().contains("Protocol"));
+        }
+        Ok(_) => {
+            return Err("Expected send to fail after shutdown, but it succeeded".into());
+        }
+    }
+    
+    // Try to get address after shutdown - should fail
+    let addr_result = node1.get_node_addr().await;
+    
+    match addr_result {
+        Err(e) => {
+            println!("✅ Expected error getting address after shutdown: {}", e);
+            assert!(e.to_string().contains("not started") || e.to_string().contains("shutdown") || e.to_string().contains("Protocol"));
+        }
+        Ok(_) => {
+            return Err("Expected get_node_addr to fail after shutdown, but it succeeded".into());
+        }
+    }
+    
+    // Cleanup remaining node
+    node2.shutdown()?;
+    sleep(Duration::from_millis(50)).await;
+    
+    Ok(())
+}
+
+// Helper functions
+fn create_test_tensor(shape: Vec<i64>, dtype: String) -> TensorData {
+    let num_elems = shape.iter().product::<i64>() as usize;
     let mut bytes = Vec::with_capacity(num_elems * 4);
+    
     for i in 0..num_elems {
         let v = i as f32;
         bytes.extend_from_slice(&v.to_ne_bytes());
     }
-    let tensor = TensorData { metadata: metadata.clone(), data: bytes.clone() };
-    println!("Created test tensor of {} elements", num_elems);
-
-    // Register the tensor on node1
-    println!("Registering tensor on node1...");
-    node1.register_tensor("test_tensor".to_string(), tensor.clone())?;
-
-    // Send the tensor from node1 to node2 using the NodeTicket
-    println!("Sending tensor from node1 to node2...");
-    node1.send_tensor_direct(addr2.clone(), "test_tensor".to_string(), tensor.clone()).await?;
-
-    // Wait briefly for delivery
-    sleep(Duration::from_millis(100)).await;
-
-    // Attempt to receive the tensor on node2
-    println!("Receiving tensor on node2...");
-    let mut received = None;
-    for attempt in 1..=50 {
-        if let Some(tx) = node2.receive_tensor().await? {
-            received = Some(tx);
-            println!("✅ Received on attempt {}", attempt);
-            break;
-        }
-        sleep(Duration::from_millis(100)).await;
+    
+    let metadata = TensorMetadata {
+        shape,
+        dtype,
+        requires_grad: false,
+    };
+    
+    TensorData {
+        metadata,
+        data: bytes,
     }
+}
 
-    // Validate the result
-    let received = received.expect("Failed to receive tensor");
-    // Compare metadata fields individually since TensorMetadata doesn't implement PartialEq
-    assert_eq!(received.metadata.shape, metadata.shape);
-    assert_eq!(received.metadata.dtype, metadata.dtype);
-    assert_eq!(received.metadata.requires_grad, metadata.requires_grad);
-    assert_eq!(received.data, bytes);
-    println!("✅ SUCCESS: Tensor metadata and data match!");
+async fn wait_for_tensor(node: &tensor_protocol::TensorNode, max_attempts: i32) -> Result<TensorData, Box<dyn Error>> {
+    for attempt in 1..=max_attempts {
+        if let Some(tensor) = node.receive_tensor().await? {
+            println!("✅ Received tensor on attempt {}", attempt);
+            return Ok(tensor);
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+    Err("Failed to receive tensor within timeout".into())
+}
 
-    // Clean up
-    node1.shutdown()?;
-    node2.shutdown()?;
-    println!("Shut down nodes.");
+fn validate_tensor(expected: &TensorData, received: &TensorData) -> Result<(), Box<dyn Error>> {
+    if expected.metadata.shape != received.metadata.shape {
+        return Err(format!("Shape mismatch: expected {:?}, got {:?}", expected.metadata.shape, received.metadata.shape).into());
+    }
+    if expected.metadata.dtype != received.metadata.dtype {
+        return Err(format!("Dtype mismatch: expected {}, got {}", expected.metadata.dtype, received.metadata.dtype).into());
+    }
+    if expected.metadata.requires_grad != received.metadata.requires_grad {
+        return Err(format!("Requires_grad mismatch: expected {}, got {}", expected.metadata.requires_grad, received.metadata.requires_grad).into());
+    }
+    if expected.data != received.data {
+        return Err(format!("Data mismatch: expected {} bytes, got {} bytes", expected.data.len(), received.data.len()).into());
+    }
     Ok(())
+}
+
+async fn cleanup_nodes(nodes: &[tensor_protocol::TensorNode]) {
+    for node in nodes {
+        let _ = node.shutdown();
+    }
+    // Give time for cleanup
+    sleep(Duration::from_millis(50)).await;
 } 

--- a/protocol/src/bin/test_tensor_protocol.rs
+++ b/protocol/src/bin/test_tensor_protocol.rs
@@ -18,8 +18,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Obtain their addresses
     let addr1 = node1.get_node_addr().await?;
     let addr2 = node2.get_node_addr().await?;
-    println!("Node1 address: {}", addr1);
-    println!("Node2 address: {}", addr2);
+    println!("Node1 NodeTicket: {}", addr1);
+    println!("Node2 NodeTicket: {}", addr2);
 
     // Construct a test tensor: shape [3,4], float32, deterministic data
     let shape = vec![3, 4];
@@ -39,7 +39,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     println!("Registering tensor on node1...");
     node1.register_tensor("test_tensor".to_string(), tensor.clone())?;
 
-    // Send the tensor from node1 to node2
+    // Send the tensor from node1 to node2 using the NodeTicket
     println!("Sending tensor from node1 to node2...");
     node1.send_tensor_direct(addr2.clone(), "test_tensor".to_string(), tensor.clone()).await?;
 

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -420,7 +420,7 @@ impl TensorNode {
     #[uniffi::method(async_runtime = "tokio")]
     pub async fn send_tensor_direct(
         &self,
-        peer_addr: String,      // The address of the peer (like a mailing address)
+        peer_addr: String,      // The NodeTicket of the peer (contains all addressing info)
         tensor_name: String,    // A name for the tensor
         tensor: TensorData,     // The actual tensor data
     ) -> Result<(), TensorError> {
@@ -444,19 +444,23 @@ impl TensorNode {
 
         debug!("Sending tensor '{}' to {}", tensor_name, peer_addr);
 
-        println!("🔍 [SEND] Parsing peer address: {}", peer_addr);
-        // Parse the peer address from a string into a NodeAddr
-        // This is like converting a written address into GPS coordinates
+        println!("🔍 [SEND] Parsing peer NodeTicket: {}", peer_addr);
+        // ✅ FIX: Parse as NodeTicket instead of expecting a specific format
+        // This automatically handles both relay URLs and direct addresses
         let ticket: NodeTicket = peer_addr.parse().map_err(|e| {
-            println!("❌ [SEND] Failed to parse peer address: {:?}", e);
+            println!("❌ [SEND] Failed to parse NodeTicket: {:?}", e);
             e
         })?;
         let node_addr: NodeAddr = ticket.into();
-        println!("✅ [SEND] Peer address parsed successfully");
+        
+        println!("✅ [SEND] NodeTicket parsed successfully");
+        println!("🔍 [SEND] Peer node_id: {}", node_addr.node_id.fmt_short());
+        println!("🔍 [SEND] Peer relay_url: {:?}", node_addr.relay_url);
+        println!("🔍 [SEND] Peer direct_addresses: {} found", node_addr.direct_addresses.len());
 
         println!("🔗 [SEND] Connecting to peer...");
         // Connect to the peer
-        // This is like making a phone call to the other peer
+        // Iroh will automatically try both relay and direct addresses
         let connection = endpoint.connect(node_addr, TENSOR_ALPN).await
             .map_err(|e: ConnectError| {
                 println!("❌ [SEND] Connection failed: {}", e);
@@ -574,25 +578,33 @@ impl TensorNode {
             })?;
         
         println!("✅ [GET_ADDR] Got initialized result: {:?}", result);
-        println!("🔍 [GET_ADDR] Checking relay_url...");
+        println!("🔍 [GET_ADDR] Checking addresses...");
         println!("🔍 [GET_ADDR] relay_url is_some: {}", result.relay_url.is_some());
+        println!("🔍 [GET_ADDR] direct_addresses count: {}", result.direct_addresses.len());
         
         if let Some(ref relay_url) = result.relay_url {
             println!("✅ [GET_ADDR] Found relay_url: {:?}", relay_url);
-        } else {
-            println!("❌ [GET_ADDR] relay_url is None!");
-            println!("🔍 [GET_ADDR] Full result details: {:#?}", result);
         }
         
-        // Extract the relay URL (this is how other peers can reach us)
-        let addr = result.relay_url.ok_or_else(|| {
-            println!("❌ [GET_ADDR] Address not available - relay_url is None");
-            TensorError::Protocol { message: "Address not available".into() }
-        })?;
-
-        let addr_string = format!("{:?}", addr);
-        println!("🎉 [GET_ADDR] Successfully got address: {}", addr_string);
-        Ok(addr_string)
+        for (i, direct_addr) in result.direct_addresses.iter().enumerate() {
+            println!("✅ [GET_ADDR] Direct address {}: {}", i, direct_addr);
+        }
+        
+        // ✅ FIX: Create a proper NodeTicket with ALL address info (relay + direct)
+        // This works whether we have relay servers, direct addresses, or both!
+        if result.relay_url.is_none() && result.direct_addresses.is_empty() {
+            println!("❌ [GET_ADDR] No addressing information available");
+            return Err(TensorError::Protocol { 
+                message: "No relay URL or direct addresses available".into() 
+            });
+        }
+        
+        // Create a NodeTicket containing the complete addressing information
+        let node_ticket = NodeTicket::new(result);
+        let ticket_string = node_ticket.to_string();
+        
+        println!("🎉 [GET_ADDR] Created NodeTicket: {}", ticket_string);
+        Ok(ticket_string)
     }
 
     // Stores a tensor locally so others can request it (like putting something in storage)

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -426,11 +426,11 @@ impl TensorNode {
     ) -> Result<(), TensorError> {
         println!("📤 [SEND] Sending tensor '{}' to {} (size: {} bytes)", tensor_name, peer_addr, tensor.data.len());
         
-        println!("🔒 [SEND] Acquiring endpoint lock...");
+        // println!("🔒 [SEND] Acquiring endpoint lock...");
         // Get our endpoint (make sure we're started)
         let endpoint = {
             let endpoint_guard = self.endpoint.lock().unwrap();
-            println!("🔒 [SEND] Endpoint lock acquired");
+            // println!("🔒 [SEND] Endpoint lock acquired");
             
             endpoint_guard.as_ref()
                 .ok_or_else(|| {
@@ -440,7 +440,7 @@ impl TensorNode {
                 .clone()
         };
         
-        println!("✅ [SEND] Endpoint acquired successfully");
+        // println!("✅ [SEND] Endpoint acquired successfully");
 
         debug!("Sending tensor '{}' to {}", tensor_name, peer_addr);
 
@@ -454,11 +454,11 @@ impl TensorNode {
         let node_addr: NodeAddr = ticket.into();
         
         println!("✅ [SEND] NodeTicket parsed successfully");
-        println!("🔍 [SEND] Peer node_id: {}", node_addr.node_id.fmt_short());
-        println!("🔍 [SEND] Peer relay_url: {:?}", node_addr.relay_url);
-        println!("🔍 [SEND] Peer direct_addresses: {} found", node_addr.direct_addresses.len());
+        // println!("🔍 [SEND] Peer node_id: {}", node_addr.node_id.fmt_short());
+        // println!("🔍 [SEND] Peer relay_url: {:?}", node_addr.relay_url);
+        // println!("🔍 [SEND] Peer direct_addresses: {} found", node_addr.direct_addresses.len());
 
-        println!("🔗 [SEND] Connecting to peer...");
+        // println!("🔗 [SEND] Connecting to peer...");
         // Connect to the peer
         // Iroh will automatically try both relay and direct addresses
         let connection = endpoint.connect(node_addr, TENSOR_ALPN).await
@@ -478,7 +478,7 @@ impl TensorNode {
         
         println!("✅ [SEND] Bidirectional stream opened");
 
-        println!("📦 [SEND] Creating message...");
+        // println!("📦 [SEND] Creating message...");
         // Create a message containing our tensor
         let message = TensorMessage::Response {
             tensor_name: tensor_name.clone(),
@@ -494,7 +494,7 @@ impl TensorNode {
         
         println!("✅ [SEND] Message serialized successfully (size: {} bytes)", message_bytes.len());
         
-        println!("📡 [SEND] Writing message bytes to stream...");
+        // println!("📡 [SEND] Writing message bytes to stream...");
         // Send the bytes over the network
         send.write_all(&message_bytes).await.map_err(|e| {
             println!("❌ [SEND] Failed to write message bytes: {:?}", e);
@@ -518,9 +518,9 @@ impl TensorNode {
     pub async fn receive_tensor(&self) -> Result<Option<TensorData>, TensorError> {
         println!("📬 [RECEIVE] Checking for received tensors...");
         
-        println!("🔒 [RECEIVE] Acquiring receiver lock...");
+        // println!("🔒 [RECEIVE] Acquiring receiver lock...");
         let mut receiver_guard = self.receiver_rx.lock().unwrap();
-        println!("🔒 [RECEIVE] Receiver lock acquired");
+        // println!("🔒 [RECEIVE] Receiver lock acquired");
         
         if let Some(rx) = receiver_guard.as_mut() {
             println!("✅ [RECEIVE] Receiver channel found, trying to receive...");
@@ -578,9 +578,9 @@ impl TensorNode {
             })?;
         
         println!("✅ [GET_ADDR] Got initialized result: {:?}", result);
-        println!("🔍 [GET_ADDR] Checking addresses...");
-        println!("🔍 [GET_ADDR] relay_url is_some: {}", result.relay_url.is_some());
-        println!("🔍 [GET_ADDR] direct_addresses count: {}", result.direct_addresses.len());
+        // println!("🔍 [GET_ADDR] Checking addresses...");
+        // println!("🔍 [GET_ADDR] relay_url is_some: {}", result.relay_url.is_some());
+        // println!("🔍 [GET_ADDR] direct_addresses count: {}", result.direct_addresses.len());
         
         if let Some(ref relay_url) = result.relay_url {
             println!("✅ [GET_ADDR] Found relay_url: {:?}", relay_url);


### PR DESCRIPTION
Only fixed for peers within the same network. 
`NodeAddr` contains BOTH `relay_url` and `direct_addresses`, Iroh can connect using EITHER relay OR direct addresses. We were just using `relay_url`, where it was not needed. Our previous code extracted only `relay_url` and discarded  `direct_addresses`.

Introduced the concept of NodeTicket, which contains the information of both `relay_url` and `direct_addresses`. In theory, it should shift to relays if the direct connection is not available. Still have to test that though.